### PR TITLE
Provide more information about the repository

### DIFF
--- a/lib/Module/Install/GithubMeta.pm
+++ b/lib/Module/Install/GithubMeta.pm
@@ -19,7 +19,13 @@ sub githubmeta {
   $git_url =~ s![\w\-]+\@([^:]+):!git://$1/!;
   $http_url =~ s![\w\-]+\@([^:]+):!http://$1/!;
   $http_url =~ s!\.git$!/tree!;
-  $self->repository( $git_url );
+  $self->repository(
+      {
+          type => 'git',
+          url  => $git_url,
+          web  => $http_url,
+      },
+  );
   $self->homepage( $http_url ) unless $self->homepage();
   return 1;
 }


### PR DESCRIPTION
Instead of:

```
  repository: git://github.com/sartak/pod-cpandoc.git
```

provide:

```
  repository:
    type: git
    url: git://github.com/sartak/pod-cpandoc.git
    web: http://github.com/sartak/pod-cpandoc/tree
```

which Moose uses and metacpan understands.
