### PR TITLE
fix github url

### DIFF
--- a/lib/Module/Install/GithubMeta.pm
+++ b/lib/Module/Install/GithubMeta.pm
@@ -21,7 +21,7 @@ sub githubmeta {
   my $http_url = $git_url;
   $git_url =~ s![\w\-]+\@([^:]+):!git://$1/!;
   $http_url =~ s![\w\-]+\@([^:]+):!https://$1/!;
-  $http_url =~ s!\.git$!/tree!;
+  $http_url =~ s!\.git$!/!;
   $self->repository( $git_url );
   $self->homepage( $http_url ) unless $self->homepage();
   return 1;


### PR DESCRIPTION
When appending /tree to the github url, it will result in a 404. You can try that on
http://search.cpan.org/dist/Module-Install-GithubMeta/

When removing the "tree" it just works.

Thanks
